### PR TITLE
Add missing package dependency for RHEL based systems

### DIFF
--- a/tasks/prereq.yml
+++ b/tasks/prereq.yml
@@ -8,7 +8,7 @@
 
 - name: "Install yum packages"
   yum: name={{ item }} state=present
-  with_items: ['perl-Switch', 'perl-DateTime',  'perl-Sys-Syslog', 'perl-LWP-Protocol-https']
+  with_items: ['perl-Switch', 'perl-DateTime',  'perl-Sys-Syslog', 'perl-LWP-Protocol-https', 'perl-Digest-SHA']
   when: ansible_os_family == "RedHat"
   become: True
 


### PR DESCRIPTION
`perl-Digest-SHA` is missing as a dependency.